### PR TITLE
Fix panic when decoding file with EOF

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -278,7 +278,7 @@ impl Decoder
         loop
         {
             // read a byte
-            let m = read_byte(&mut buf);
+            let m = read_byte(&mut buf)?;
 
             // Last byte should be 0xFF to confirm existence of a marker since markers look
             // like OxFF(some marker data)

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -33,7 +33,7 @@ pub(crate) fn parse_huffman<R>(decoder: &mut Decoder, mut buf: &mut R) -> Result
     while length_read < dht_length
     {
         // HT information
-        let ht_info = read_byte(&mut buf);
+        let ht_info = read_byte(&mut buf)?;
 
         // third bit indicates whether the huffman encoding is DC or AC type
         let dc_or_ac = (ht_info >> 4) & 0x01;
@@ -109,7 +109,7 @@ pub(crate) fn parse_dqt<R>(decoder: &mut Decoder, buf: &mut R) -> Result<(), Dec
     // A single DQT header may have multiple QT's
     while qt_length > length_read
     {
-        let qt_info = read_byte(&mut buf);
+        let qt_info = read_byte(&mut buf)?;
 
         // If the first bit is set,panic
         if ((qt_info >> 1) & 0x01) != 0
@@ -186,7 +186,7 @@ pub(crate) fn parse_start_of_frame<R>(
 
     // usually 8, but can be 12 and 16, we currently support only 8
     // so sorry about that 12 bit images
-    let dt_precision = read_byte(&mut buf);
+    let dt_precision = read_byte(&mut buf)?;
 
     if dt_precision != 8
     {
@@ -227,7 +227,7 @@ pub(crate) fn parse_start_of_frame<R>(
     }
 
     // Number of components for the image.
-    let num_components = read_byte(&mut buf);
+    let num_components = read_byte(&mut buf)?;
 
     // length should be equal to num components
     if length != u16::from(8 + 3 * num_components)
@@ -329,7 +329,7 @@ pub(crate) fn parse_sos<R>(buf: &mut R, image: &mut Decoder) -> Result<(), Decod
     let ls = read_u16_be(&mut buf)?;
 
     // Number of image components in scan
-    let ns = read_byte(&mut buf);
+    let ns = read_byte(&mut buf)?;
     image.num_scans = ns;
 
     if ls != u16::from(6 + 2 * ns)
@@ -352,12 +352,12 @@ pub(crate) fn parse_sos<R>(buf: &mut R, image: &mut Decoder) -> Result<(), Decod
     for i in 0..ns
     {
         // CS_i parameter, I don't need it so I might as well delete it
-        let id = read_byte(&mut buf);
+        let id = read_byte(&mut buf)?;
 
         // DC and AC huffman table position
         // top 4 bits contain dc huffman destination table
         // lower four bits contain ac huffman destination table
-        let y = read_byte(&mut buf);
+        let y = read_byte(&mut buf)?;
         let mut j = 0;
         while j < image.info.components
         {
@@ -382,12 +382,12 @@ pub(crate) fn parse_sos<R>(buf: &mut R, image: &mut Decoder) -> Result<(), Decod
         // Page 42
 
         // Start of spectral / predictor selection. (between 0 and 63)
-        image.spec_start = read_byte(&mut buf) & 63;
+        image.spec_start = read_byte(&mut buf)? & 63;
 
         // End of spectral selection
-        image.spec_end = read_byte(&mut buf) & 63;
+        image.spec_end = read_byte(&mut buf)? & 63;
 
-        let bit_approx = read_byte(&mut buf);
+        let bit_approx = read_byte(&mut buf)?;
 
         // successive approximation bit position high
         image.succ_high = bit_approx >> 4;

--- a/src/mcu_prog.rs
+++ b/src/mcu_prog.rs
@@ -401,15 +401,15 @@ fn get_marker(reader: &mut Cursor<Vec<u8>>, stream: &mut BitStream) -> Option<Ma
     let len = u64::try_from(reader.get_ref().len()).unwrap();
     loop
     {
-        let marker = read_byte(reader);
+        let marker = read_byte(reader).ok()?;
 
         if marker == 255
         {
-            let mut r = read_byte(reader);
+            let mut r = read_byte(reader).ok()?;
             // 0xFF 0XFF(some images may be like that)
             while r == 0xFF
             {
-                r = read_byte(reader);
+                r = read_byte(reader).ok()?;
             }
 
             if r != 0

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -248,18 +248,16 @@ impl fmt::Debug for SOFMarkers
 /// If the reader cannot read the next byte
 #[inline]
 #[allow(clippy::unused_io_amount)]
-pub fn read_byte<R>(reader: &mut R) -> u8
+pub fn read_byte<R>(reader: &mut R) -> Result<u8, DecodeErrors>
 where
     R: Read,
 {
     let mut tmp = [0; 1];
 
     // if there is no more data fill with zero
-    reader
-        .read_exact(&mut tmp)
-        .expect("Could not read from underlying buffer");
+    reader.read_exact(&mut tmp).map_err(|_| DecodeErrors::ExhaustedData)?;
 
-    tmp[0]
+    Ok(tmp[0])
 }
 
 /// Read two `u8`'s from a buffer and create a `u16` from the bytes in Big
@@ -267,9 +265,11 @@ where
 ///
 /// The first 8 bytes of the u16 are made by the first u8 read, and the second
 /// one make the last 8
+///
 /// ```text
 /// u16 => [first_u8][second_u8]
-///```
+/// ```
+///
 /// # Argument
 ///  - reader: A mutable reference to anything that implements `Read` trait
 ///
@@ -279,7 +279,6 @@ where
 /// # Panics
 /// When the bytes cannot be read
 #[inline]
-
 pub fn read_u16_be<R>(reader: &mut R) -> Result<u16, DecodeErrors>
 where
     R: Read,

--- a/tests/invalid_images.rs
+++ b/tests/invalid_images.rs
@@ -1,0 +1,10 @@
+use zune_jpeg::Decoder;
+
+#[test]
+fn eof() {
+    let mut decoder = Decoder::new();
+
+    let err = decoder.decode_buffer(&[0xff, 0xd8, 0xa4]).unwrap_err();
+
+    assert!(matches!(err, zune_jpeg::errors::DecodeErrors::ExhaustedData));
+}


### PR DESCRIPTION
Previously, any file that was cut off would panic due to the `.expect` in `read_byte`. This propagates it upwards as an error.

The test suite fails locally because `mcu_prog::try_decoding` can't find a file, but the rest of the tests seem to work fine. You might want to run it on a machine that has that file.