### PR TITLE
Fix setting the output color space

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -125,7 +125,7 @@ impl Decoder
     fn default(options: ZuneJpegOptions) -> Self
     {
         let color_convert =
-            choose_ycbcr_to_rgb_convert_func(ColorSpace::RGB, options.get_use_unsafe()).unwrap();
+            choose_ycbcr_to_rgb_convert_func(options.get_out_colorspace(), options.get_use_unsafe()).unwrap();
         Decoder {
             info: ImageInfo::default(),
             qt_tables: [None, None, None, None],


### PR DESCRIPTION
Since 0.2, setting the desired output color space doesn't work anymore, because the value is ignored. This fixes that.

`Decoder::set_output_colorspace` and `Decoder::rgba` are still broken with this PR. They would have to call `choose_ycbcr_to_rgb_convert_func` again.