### PR TITLE
Remove `cdylib` crate type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,6 @@ categories=["multimedia::images"]
 exclude=["/benches/images/","/tests/*" , "/.idea/*","/.gradle/*"]
 description="The fastest jpeg decoder in the west"
 
-[lib]
-crate-type = ["cdylib", "rlib"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 x86 = []
 default = ["x86"]


### PR DESCRIPTION
This causes "output filename collision" warnings and cryptic errors when using `zune-jpeg` as a path dependency.

Since the crate doesn't actually expose a C-compatible API, I assume this crate type was not added deliberately, and removing it should be fine.